### PR TITLE
feat: 구독 삭제 API

### DIFF
--- a/src/application/subscription/subscription.use-case.ts
+++ b/src/application/subscription/subscription.use-case.ts
@@ -1,16 +1,17 @@
-import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { HttpStatus, Inject, Injectable, Logger } from '@nestjs/common';
 import { DomainCustomException } from 'src/domain/common/errors/domain-custom-exception';
 import { DomainErrorCode } from 'src/domain/common/errors/domain-error-code';
 import { StreamerService } from 'src/domain/streamer/streamer.service';
 import { SubscriptionWithChannelResult } from 'src/domain/subscription/result/subscription-with-channel.result';
 import { SubscriptionService } from 'src/domain/subscription/subscription.service';
-import { TransactionManager } from '../common/transaction-manager';
+import { TRANSACTION_MANAGER, TransactionManager } from '../common/transaction-manager';
 
 @Injectable()
 export class SubscriptionUseCase {
   constructor(
     private readonly subscriptionService: SubscriptionService,
     private readonly streamerService: StreamerService,
+    @Inject(TRANSACTION_MANAGER)
     private readonly transactionManager: TransactionManager
   ) {}
 
@@ -55,5 +56,9 @@ export class SubscriptionUseCase {
     }
 
     await this.subscriptionService.subscribe(userId, streamer.streamerId);
+  }
+
+  async unsubscribe(subscriptionId: number) {
+    await this.subscriptionService.unsubscribe(subscriptionId);
   }
 }

--- a/src/domain/subscription/subscription.entity.ts
+++ b/src/domain/subscription/subscription.entity.ts
@@ -21,4 +21,10 @@ export class SubscriptionEntity {
 
     return this;
   }
+
+  disconnect() {
+    this.isConnected = false;
+
+    return this;
+  }
 }

--- a/src/domain/subscription/subscription.repository.ts
+++ b/src/domain/subscription/subscription.repository.ts
@@ -6,6 +6,7 @@ export const SUBSCRIPTION_REPOSITORY = Symbol('SubscriptionRepository');
 
 export interface SubscriptionRepository {
   getSubscriptions(userId: number): Promise<SubscriptionWithChannelResult[]>;
+  getSubscriptionById(subscriptionId: number): Promise<SubscriptionEntity | null>;
   getSubscription(userId: number, streamerId: number): Promise<SubscriptionEntity | null>;
   updateSubscription(subscription: SubscriptionEntity): Promise<void>;
   createSubscription(userId: number, streamerId: number): Promise<void>;

--- a/src/infrastructure/subscription/subscription.core-repository.ts
+++ b/src/infrastructure/subscription/subscription.core-repository.ts
@@ -103,4 +103,25 @@ export class SubscriptionCoreRepository implements SubscriptionRepository {
       },
     }));
   }
+
+  async getSubscriptionById(subscriptionId: number): Promise<SubscriptionEntity | null> {
+    const subscription = await this.prisma.subscription.findUnique({
+      where: {
+        subscription_id: subscriptionId,
+      },
+    });
+
+    if (!subscription) {
+      return null;
+    }
+
+    return new SubscriptionEntity(
+      Number(subscription.subscription_id),
+      Number(subscription.user_id),
+      Number(subscription.streamer_id),
+      subscription.is_connected,
+      subscription.created_at,
+      subscription.updated_at
+    );
+  }
 }

--- a/src/interfaces/controller/common/dto/field-error-map.ts
+++ b/src/interfaces/controller/common/dto/field-error-map.ts
@@ -41,4 +41,7 @@ export const FieldConstraintErrorMap: Partial<
   channelUrl: {
     isUrl: RequestErrorCode.INVALID_CHANNEL_URL,
   },
+  subscriptionId: {
+    isNumber: RequestErrorCode.INVALID_SUBSCRIPTION_ID,
+  },
 };

--- a/src/interfaces/controller/subscription/dto/unsubscribe-channel.request.dto.ts
+++ b/src/interfaces/controller/subscription/dto/unsubscribe-channel.request.dto.ts
@@ -1,7 +1,7 @@
 import { Type } from 'class-transformer';
 import { IsNumber } from 'class-validator';
 
-export class unsubscribeChannelRequestDto {
+export class UnsubscribeChannelRequestDto {
   @Type(() => Number)
   @IsNumber()
   subscriptionId: number;

--- a/src/interfaces/controller/subscription/dto/unsubscribe-channel.request.dto.ts
+++ b/src/interfaces/controller/subscription/dto/unsubscribe-channel.request.dto.ts
@@ -1,0 +1,8 @@
+import { Type } from 'class-transformer';
+import { IsNumber } from 'class-validator';
+
+export class unsubscribeChannelRequestDto {
+  @Type(() => Number)
+  @IsNumber()
+  subscriptionId: number;
+}

--- a/src/interfaces/controller/subscription/subscription.controller.ts
+++ b/src/interfaces/controller/subscription/subscription.controller.ts
@@ -6,7 +6,7 @@ import { Response } from 'express';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { UserId } from '../common/decorators/user.decorator';
 import { SubscribeChannelRequestDto } from './dto/subscribe-channel.request.dto';
-import { unsubscribeChannelRequestDto } from './dto/unsubscribe-channel.request.dto';
+import { UnsubscribeChannelRequestDto } from './dto/unsubscribe-channel.request.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('subscriptions')
@@ -40,7 +40,7 @@ export class SubscriptionController {
   @Delete(':subscriptionId')
   async unsubscribeChannel(
     @UserId() userId: number,
-    @Param() unsubscribeChannelRequestDto: unsubscribeChannelRequestDto,
+    @Param() unsubscribeChannelRequestDto: UnsubscribeChannelRequestDto,
     @Res() res: Response
   ) {
     const { subscriptionId } = unsubscribeChannelRequestDto;

--- a/src/interfaces/controller/subscription/subscription.controller.ts
+++ b/src/interfaces/controller/subscription/subscription.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post, Res, UseGuards } from '@nestjs/common';
 import { SubscriptionUseCase } from 'src/application/subscription/subscription.use-case';
 import { ResultResponseDto } from '../common/dto/result.response.dto';
 import { GetSubscriptionsResponseDto } from './dto/subscription.response.dto';
@@ -6,6 +6,7 @@ import { Response } from 'express';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { UserId } from '../common/decorators/user.decorator';
 import { SubscribeChannelRequestDto } from './dto/subscribe-channel.request.dto';
+import { unsubscribeChannelRequestDto } from './dto/unsubscribe-channel.request.dto';
 
 @UseGuards(JwtAuthGuard)
 @Controller('subscriptions')
@@ -34,5 +35,18 @@ export class SubscriptionController {
     await this.subscriptionUseCase.subscribe(userId, channelUrl);
 
     return res.status(201).json(ResultResponseDto.success());
+  }
+
+  @Delete(':subscriptionId')
+  async unsubscribeChannel(
+    @UserId() userId: number,
+    @Param() unsubscribeChannelRequestDto: unsubscribeChannelRequestDto,
+    @Res() res: Response
+  ) {
+    const { subscriptionId } = unsubscribeChannelRequestDto;
+
+    await this.subscriptionUseCase.unsubscribe(subscriptionId);
+
+    return res.status(200).json(ResultResponseDto.success());
   }
 }


### PR DESCRIPTION
## 요약

- 구독 삭제 API
Close: #38  

## 변경 사항

- [ ]  로그인된 사용자인지 확인. (JWT 토큰 검증)
    - [ ]  로그인된 사용자가 아니라면 요청 거부.
    - [ ]  “인증되지 않은 사용자입니다.” 에러메시지와 함께 **`401 Unauthorization`** 에러 응답
    - [ ]  JWT 토큰에서 `userId` 정보 확인
- [ ]  요청 바디 유효성 검사
    - [ ]  `subscriptionId` 필수값 체크
    - [ ]  필수값 누락시 “구독ID는 필수입니다.” 에러메시지와 함께 **`400 Bad Request`** 에러 응답
- [ ]  `subscriptionId`에 해당하는 구독 정보를 삭제한다.
    - [ ]  목록에 있고, 삭제에 성공했으면 **`200 OK`** 성공 응답.
    - [ ]  등록되지 않는 구독ID일 경우 **`404 Not Found`** 에러 응답.
    - [ ]  그외 기타 오류는 실패 응답 전송
        - [ ]  **`500 Internal Server Error`** 에러 응답

## 체크리스트

- [ ] 이해하기 어려운 코드에는 주석을 추가했습니다  
- [ ] 관련 문서를 수정했습니다  
- [ ] 새로운 경고가 발생하지 않습니다  
- [ ] 수정한 기능 또는 추가한 기능에 대해 테스트를 작성했습니다  
- [ ] 의존성 있는 변경 사항이 병합 및 배포되었습니다

## 관련 이슈

<!-- 이 PR이 해결하는 관련 이슈나 버그가 있다면 연결해 주세요. 어떤 문제를 해결하는 코드인지 맥락을 제공합니다. -->

## 리뷰 반영 사항

<!-- PR리뷰 반형 사항 -->

<details>
<summary><strong>선택 항목 펼치기</strong></summary>

## 스크린샷

<!-- 시각적인 변경 사항이 있다면 스크린샷이나 GIF를 포함해 주세요. 리뷰어가 쉽게 이해할 수 있습니다. -->

## 테스트 방법

<!-- PR에서 수행한 변경 사항을 어떻게 테스트할 수 있는지 설명해 주세요. 리뷰어가 직접 확인할 수 있도록 돕습니다. -->

## 리뷰어 참고사항

<!-- 리뷰어에게 특별히 알려야 할 사항이나 고려할 점이 있다면 여기에 작성해 주세요. -->

</details>