### PR TITLE
fix: 탈퇴한 이메일 계정으로 재가입 가능하도록 처리

### DIFF
--- a/src/application/auth/auth.use-case.ts
+++ b/src/application/auth/auth.use-case.ts
@@ -4,7 +4,6 @@ import { SignupCommand } from 'src/domain/auth/command/signup.command';
 import { SocialLoginCommand } from 'src/domain/auth/command/social-login.command';
 import { LoginToken } from 'src/domain/auth/login-token';
 import { NeedSignupResponse } from 'src/domain/auth/need-signup.response';
-import { UserEntity } from 'src/domain/user/user.entity';
 import { UserService } from 'src/domain/user/user.service';
 import { Transactional } from 'src/infrastructure/prisma/transactional.decorator';
 import { JwtUtil } from 'src/support/jwt.util';
@@ -29,12 +28,9 @@ export class AuthUseCase {
 
     const userInfo = await this.authService.getOauthUserInfo(provider, accessToken);
 
-    const user: UserEntity | null = await this.userService.getUserByProviderAndEmail(
-      provider,
-      userInfo.email
-    );
+    const user = await this.userService.getUserByProviderAndEmail(provider, userInfo.email);
 
-    if (!user) {
+    if (!user || user.isDeleted) {
       return {
         needSignup: true,
         user: {

--- a/src/domain/user/user.repository.ts
+++ b/src/domain/user/user.repository.ts
@@ -11,8 +11,9 @@ export interface UserRepository {
   findTokenById(userId: number): Promise<TokenEntity | null>;
   updateRefreshToken(userId: number, refreshToken: string): Promise<TokenEntity>;
   createUser(command: SignupCommand): Promise<number>;
-  createToken(userId: number): Promise<void>;
+  upsertToken(userId: number): Promise<void>;
   findByNickname(nickname: string): Promise<UserEntity | null>;
   signout(command: UserRequestCommand): Promise<boolean>;
   logout(requestCommand: LogoutRequestCommand): Promise<UserEntity>;
+  restoreUser(userId: number, command: SignupCommand): Promise<void>;
 }


### PR DESCRIPTION
## 요약

> 회원 탈퇴 시 동일 이메일 계정으로 로그인 되지 않는 버그
Closes #48 

## 변경 사항

### ✅  회원가입 로직 변경사항
1. `email`과 `provider`로 기존 사용자를 조회
2. 사용자가 조회되지 않은 경우 → 새 사용자 생성
3. 사용자가 조회되었고, `is_deleted`: `true`인 경우
-> `nickname` 정보를 업데이트
-> `is_deleted` 값을 `false`로 변경하여 계정 복구

### ✅  회원탈퇴 로직 추가사항
1. 회원탈퇴 시 기존 `nickname`을 `''`공백 처리

## 체크리스트

- [ ] 이해하기 어려운 코드에는 주석을 추가했습니다  
- [ ] 관련 문서를 수정했습니다  
- [ ] 새로운 경고가 발생하지 않습니다  
- [ ] 수정한 기능 또는 추가한 기능에 대해 테스트를 작성했습니다  
- [ ] 의존성 있는 변경 사항이 병합 및 배포되었습니다

## 관련 이슈

- #48 

## 리뷰 반영 사항

<!-- PR리뷰 반형 사항 -->

<details>
<summary><strong>선택 항목 펼치기</strong></summary>

## 스크린샷

<!-- 시각적인 변경 사항이 있다면 스크린샷이나 GIF를 포함해 주세요. 리뷰어가 쉽게 이해할 수 있습니다. -->

## 테스트 방법

<!-- PR에서 수행한 변경 사항을 어떻게 테스트할 수 있는지 설명해 주세요. 리뷰어가 직접 확인할 수 있도록 돕습니다. -->

## 리뷰어 참고사항

<!-- 리뷰어에게 특별히 알려야 할 사항이나 고려할 점이 있다면 여기에 작성해 주세요. -->

</details>